### PR TITLE
Fix for 3rd ToS LFR Wing

### DIFF
--- a/SavedInstances/SavedInstances.lua
+++ b/SavedInstances/SavedInstances.lua
@@ -182,7 +182,7 @@ addon.LFRInstances = {
 
   [1494] = { total=3, base=1, parent=1527, altid=nil, remap={ 1, 2, 3 } }, -- ToS1: The Gates of Hell (6/27/17)
   [1495] = { total=3, base=4, parent=1527, altid=nil, remap={ 1, 2, 3 } }, -- ToS2: Wailing Halls (7/11/17)
-  [1496] = { total=2, base=7, parent=1527, altid=nil, remap={ 7, 8 } }, -- ToS3: Chamber of the Avatar (7/25/17)
+  [1496] = { total=2, base=7, parent=1527, altid=nil, remap={ 1, 2 } }, -- ToS3: Chamber of the Avatar (7/25/17)
   [1497] = { total=1, base=9, parent=1527, altid=nil, remap={ 9 } }, -- ToS4: Deceiver's Fall (8/8/17)
 }
 local tmp = {}


### PR DESCRIPTION
Fixed the loot lockout status for Maiden of Vigilance and Avatar of Sargeras for ToS LFR Wing 3 - Chamber of the Avatar