### PR TITLE
Visual tweaks + SotT Fix

### DIFF
--- a/SavedInstances/SavedInstances.lua
+++ b/SavedInstances/SavedInstances.lua
@@ -4256,49 +4256,63 @@ function core:ShowTooltip(anchorframe)
     end
   end
 
-  if vars.db.Tooltip.MythicKeyBest or showall then
-    local show = false
-    for toon, t in cpairs(vars.db.Toons, true) do
-      if t.MythicKeyBest then
-        if t.MythicKeyBest.level and t.MythicKeyBest.level > 0 then
-          show = true
-          addColumns(columns, toon, tooltip)
-        end
-        if t.MythicKeyBest.WeeklyReward then
-          show = true
-          addColumns(columns, toon, tooltip)
-        end
-      end
-    end
-    if show then
-      if not firstcategory and vars.db.Tooltip.CategorySpaces then
-        addsep()
-      end
-      show = tooltip:AddLine(YELLOWFONT .. L["Mythic Key Best"] .. FONTEND)
-    end
-    for toon, t in cpairs(vars.db.Toons, true) do
-      if t.MythicKeyBest then
-        local keydesc = ""
-        if t.MythicKeyBest.level and t.MythicKeyBest.level > 0 then
-          keydesc = t.MythicKeyBest.level
-        end
-        if t.MythicKeyBest.WeeklyReward then
-          if keydesc == "" then
-            keydesc = "0"
-          end
-          local lastlevel = ""
-          if t.MythicKeyBest.LastWeekLevel and t.MythicKeyBest.LastWeekLevel > 0 then
-            lastlevel = t.MythicKeyBest.LastWeekLevel
-          end
-          keydesc = keydesc .."(".. lastlevel ..L["Last Week Reward Usable"].. ")"
-        end
-        if keydesc ~= "" then
-          local col = columns[toon..1]
-          tooltip:SetCell(show, col, keydesc , "CENTER",maxcol)
-        end
-      end
-    end
-  end
+	if vars.db.Tooltip.MythicKeyBest or showall then
+		local show = false
+		for toon, t in cpairs(vars.db.Toons, true) do
+			if t.MythicKeyBest then
+				if t.MythicKeyBest.level and t.MythicKeyBest.level > 0 then
+					show = true
+					addColumns(columns, toon, tooltip)
+				end
+				if t.MythicKeyBest.WeeklyReward then
+					show = true
+					addColumns(columns, toon, tooltip)
+				end
+			end
+		end
+    	if show then
+			if not firstcategory and vars.db.Tooltip.CategorySpaces then
+				addsep()
+			end
+			show = tooltip:AddLine(YELLOWFONT .. L["Current Mythic+"] .. FONTEND)
+		end
+		for toon, t in cpairs(vars.db.Toons, true) do
+			if t.MythicKeyBest then
+				local keydesc = ""
+				if t.MythicKeyBest.level and t.MythicKeyBest.level > 0 then
+					keydesc = t.MythicKeyBest.level
+				end
+				if t.MythicKeyBest.WeeklyReward then
+					if keydesc == "" then
+						keydesc = "0"
+					end
+				end
+				if keydesc ~= "" then
+					local col = columns[toon..1]
+					tooltip:SetCell(show, col, keydesc , "CENTER",maxcol)
+				end
+			end
+		end
+		
+		if show then
+			if not firstcategory and vars.db.Tooltip.CategorySpaces then
+				addsep()
+			end
+			show = tooltip:AddLine(YELLOWFONT .. L["Last Week Mythic+"] .. FONTEND)
+		end
+		for toon, t in cpairs(vars.db.Toons, true) do
+			if t.MythicKeyBest then
+				local lastlevel = ""
+				if t.MythicKeyBest.LastWeekLevel and t.MythicKeyBest.LastWeekLevel > 0 then
+					lastlevel = t.MythicKeyBest.LastWeekLevel
+				end
+				if lastlevel ~= "" then
+					local col = columns[toon..1]
+					tooltip:SetCell(show, col, lastlevel, "CENTER",maxcol)
+				end
+			end
+		end
+	end
 
   if vars.db.Tooltip.DailyWorldQuest or showall then
     local show = {}

--- a/SavedInstances/SavedInstances.lua
+++ b/SavedInstances/SavedInstances.lua
@@ -62,7 +62,7 @@ local KeystoneAbbrev = {
   [227] = L["L Kara"],
   [233] = L["CoEN"],
   [234] = L["U Kara"],
-  [235] = L["SotT"],
+  [239] = L["SotT"],
 }
 
 local KeystonetoAbbrev = {

--- a/SavedInstances/SavedInstances.lua
+++ b/SavedInstances/SavedInstances.lua
@@ -4841,8 +4841,10 @@ local cdname = {
 local itemcds = { -- [itemid] = spellid
   [87214] = 126459, 	-- Blingtron 4000
   [111821] = 161414, 	-- Blingtron 5000
+  [132530] = 200146,	-- Reaves: Bling (Blingtron 6000)
   [40768] = 54710, 	-- MOLL-E
-  [49040] = 67826, 	-- Jeeves
+  [49040] = 67826,	-- Jeeves
+  [132525] = 200087,	-- Reaves: Repair
   [112059] = 163830,	-- Wormhole Centrifuge
   [48933] = 67833,	-- Wormhole Generator: Northrend
   [87215] = 126755,	-- Wormhole Generator: Pandaria


### PR DESCRIPTION
Seperated Mythic+ weekly into two lines to clean up the visuals.

Added Reaves Blingtron 6000 and Reaves repair bot.

Added correct ID for SotT M+ keys.